### PR TITLE
att-doc-retriever-sample: Add a new sample which retrieves att document

### DIFF
--- a/att_doc_retriever_sample/Dockerfile
+++ b/att_doc_retriever_sample/Dockerfile
@@ -1,0 +1,27 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+FROM ubuntu:latest AS builder
+WORKDIR /root/att_doc_retriever_sample/rs/
+COPY att_doc_retriever_sample/rs .
+RUN apt-get update && apt-get install gcc \
+                                      curl -y
+# Get Rust
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+RUN rustup target install x86_64-unknown-linux-musl
+# Build rust app
+RUN cargo build --release --target=x86_64-unknown-linux-musl
+
+
+FROM python:3.7.9-alpine3.12
+WORKDIR /root/att_doc_retriever_sample/py/
+# Copy the Rust compiled binary from previous image
+COPY --from=builder /root/att_doc_retriever_sample/rs/target/x86_64-unknown-linux-musl/release/att_doc_retriever_sample .
+# Copy the python client-server handler logic to the container
+COPY att_doc_retriever_sample/py/att_doc_retriever_sample.py .
+# Copy the client-server logic from the vsock sample to the container
+COPY vsock_sample/py/vsock-sample.py /root/vsock_sample/py/
+# 5010 is the socket port
+CMD ["/usr/local/bin/python3", "/root/att_doc_retriever_sample/py/att_doc_retriever_sample.py", "server", "5010"]
+

--- a/att_doc_retriever_sample/README.md
+++ b/att_doc_retriever_sample/README.md
@@ -1,0 +1,30 @@
+# Attestation Document Retriever Sample
+
+This is a sample application which retrieves an attestation document from an Enclave.
+The attestation document is requested from the enclave using a Rust application which
+is called by a python server for each incoming request from a python client that runs
+on the parent instance.
+
+## Build
+
+Use the steps from https://docs.aws.amazon.com/enclaves/latest/user/getting-started.html to set up a parent instance that can run the generated enclave image.
+
+Run the command below to build the docker image for the enclave.
+`$ docker build -t att-doc-retriever-sample -f Dockerfile ..`
+
+Generate the EIF using the command:
+`$ nitro-cli build-enclave --docker-uri att-doc-retriever-sample --output-file att_doc_retriever_sample.eif`
+
+## Run
+Using the nitro tools, run the enclave providing the enclave image from the build step.
+`$ nitro-cli run-enclave --cpu-count 2 --memory 512 --enclave-cid 16 --eif-path att_doc_retriever_sample.eif --debug-mode`
+
+Start the client on parent instance(Note: 16 is the enclave CID)
+`$ python3 py/att_doc_retriever_sample.py client 16 5010`
+
+On the parent instance you should see the Attestation Document sent from the enclave
+```
+$ python3 py/att_doc_retriever_sample.py client 16 5010
+Attestation { document: ...
+```
+

--- a/att_doc_retriever_sample/py/att_doc_retriever_sample.py
+++ b/att_doc_retriever_sample/py/att_doc_retriever_sample.py
@@ -1,0 +1,71 @@
+#!/usr/local/bin/env python3
+
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
+import argparse
+import inspect
+import socket
+import subprocess as sp
+import sys
+import time
+
+from os import path, getcwd
+
+# import file from different location
+current_dir = path.dirname(path.abspath(inspect.getfile(inspect.currentframe())))
+vsock_dir = path.join(path.dirname(path.dirname(current_dir)), 'vsock_sample/py')
+sys.path.insert(0, vsock_dir)
+vs = __import__('vsock-sample')
+
+# Binary executed
+RS_BINARY = path.join(current_dir, 'att_doc_retriever_sample')
+
+
+def client_handler(args):
+    client = vs.VsockStream()
+    endpoint = (args.cid, args.port)
+    client.connect(endpoint)
+    client.recv_data()
+
+
+def server_handler(args):
+    server = vs.VsockListener()
+    server.bind(args.port)
+
+    # Execute binary and send the output to client
+    proc = sp.Popen([RS_BINARY], stdout=sp.PIPE)
+    out, err = proc.communicate()
+    server.send_data(out)
+
+
+def main():
+    parser = argparse.ArgumentParser(prog='vsock-sample')
+    parser.add_argument("--version", action="version",
+                        help="Prints version information.",
+                        version='%(prog)s 0.1.0')
+    subparsers = parser.add_subparsers(title="options")
+
+    client_parser = subparsers.add_parser("client", description="Client",
+                                          help="Connect to a given cid and port.")
+    client_parser.add_argument("cid", type=int, help="The remote endpoint CID.")
+    client_parser.add_argument("port", type=int, help="The remote endpoint port.")
+    client_parser.set_defaults(func=client_handler)
+
+    server_parser = subparsers.add_parser("server", description="Server",
+                                          help="Listen on a given port.")
+    server_parser.add_argument("port", type=int, help="The local port to listen on.")
+    server_parser.set_defaults(func=server_handler)
+
+    if len(sys.argv) < 2:
+        parser.print_usage()
+        sys.exit(1)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/att_doc_retriever_sample/rs/Cargo.toml
+++ b/att_doc_retriever_sample/rs/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "att_doc_retriever_sample"
+version = "0.1.0"
+authors = ["Doru-Florin Blanzeanu <blanzed@amazon.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+serde_bytes = "0.11"
+
+[dependencies.nsm-driver]
+git = "https://github.com/aws/aws-nitro-enclaves-nsm-api.git"
+rev = "4f468c4"
+
+[dependencies.nsm-io]
+git = "https://github.com/aws/aws-nitro-enclaves-nsm-api.git"
+rev = "4f468c4"

--- a/att_doc_retriever_sample/rs/src/main.rs
+++ b/att_doc_retriever_sample/rs/src/main.rs
@@ -1,0 +1,21 @@
+use nsm_io::Request;
+use serde_bytes::ByteBuf;
+
+fn main() {
+    let nsm_fd = nsm_driver::nsm_init();
+
+    let public_key = ByteBuf::from("my super secret key");
+    let hello = ByteBuf::from("hello, world!");
+
+    let request = Request::Attestation {
+        public_key: Some(public_key),
+        user_data: Some(hello),
+        nonce: None,
+    };
+
+    let response = nsm_driver::nsm_process_request(nsm_fd, request);
+    println!("{:?}", response);
+
+    nsm_driver::nsm_exit(nsm_fd);
+}
+

--- a/vsock_sample/py/vsock-sample.py
+++ b/vsock_sample/py/vsock-sample.py
@@ -20,8 +20,17 @@ class VsockStream:
         self.sock.connect(endpoint)
 
     def send_data(self, data):
-        """Send data to the remote endpoint"""
+        """Send data to a remote endpoint"""
         self.sock.sendall(data)
+        self.sock.close()
+
+    def recv_data(self):
+        """Receive data from a remote endpoint"""
+        while True:
+            data = self.sock.recv(1024).decode()
+            if not data:
+                break
+            print(data, end='', flush=True)
         self.sock.close()
 
 
@@ -48,11 +57,20 @@ class VsockListener:
         """Receive data from a remote endpoint"""
         while True:
             (from_client, (remote_cid, remote_port)) = self.sock.accept()
-            data = from_client.recv(1024).decode()
-            if not data:
-                break
-            print(data)
+            # Read 1024 bytes at a time
+            while True:
+                data = from_client.recv(1024).decode()
+                if not data:
+                    break
+                print(data, end='', flush=True)
             from_client.close()
+
+    def send_data(self, data):
+        """Send data to a renote endpoint"""
+        while True:
+            (to_client, (remote_cid, remote_port)) = self.sock.accept()
+            to_client.sendall(data)
+            to_client.close()
 
 
 def server_handler(args):


### PR DESCRIPTION
The new sample application retrieves an Attestation document from the
enclave using a Rust application on top of which, the vsock
client/server sample is used to send the result to the parent instance

Signed-off-by: Doru-Florin Blanzeanu <blanzed@amazon.com>

Issues #5, aws/aws-nitro-enclaves-nsm-api#9


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
