### PR TITLE
vsock-sample: Fix missing Hello World on enclave console

### DIFF
--- a/vsock_sample/py/vsock-sample.py
+++ b/vsock_sample/py/vsock-sample.py
@@ -31,6 +31,7 @@ class VsockStream:
             if not data:
                 break
             print(data, end='', flush=True)
+        print()
         self.sock.close()
 
 
@@ -63,6 +64,7 @@ class VsockListener:
                 if not data:
                     break
                 print(data, end='', flush=True)
+            print()
             from_client.close()
 
     def send_data(self, data):


### PR DESCRIPTION
vsock-sample: Fix missing Hello World on enclave console

Signed-off-by: Doru-Florin Blanzeanu <blanzed@amazon.com>

*Issue #7 *

*Description of changes:*
In order to have multiple consecutive messages concatenated and not
separated by a newline, print was instructed to not add a newline
at the end. The enclave console does not print anything unless a
newline is received.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
