### PR TITLE
vsock-sample: handle client socket disconnect

### DIFF
--- a/att_doc_retriever_sample/py/att_doc_retriever_sample.py
+++ b/att_doc_retriever_sample/py/att_doc_retriever_sample.py
@@ -28,6 +28,7 @@ def client_handler(args):
     endpoint = (args.cid, args.port)
     client.connect(endpoint)
     client.recv_data()
+    client.disconnect()
 
 
 def server_handler(args):
@@ -68,4 +69,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/vsock_sample/py/vsock-sample.py
+++ b/vsock_sample/py/vsock-sample.py
@@ -22,7 +22,6 @@ class VsockStream:
     def send_data(self, data):
         """Send data to a remote endpoint"""
         self.sock.sendall(data)
-        self.sock.close()
 
     def recv_data(self):
         """Receive data from a remote endpoint"""
@@ -32,6 +31,9 @@ class VsockStream:
                 break
             print(data, end='', flush=True)
         print()
+
+    def disconnect(self):
+        """Close the client socket"""
         self.sock.close()
 
 
@@ -41,6 +43,7 @@ def client_handler(args):
     client.connect(endpoint)
     msg = 'Hello, world!'
     client.send_data(msg.encode())
+    client.disconnect()
 
 
 class VsockListener:
@@ -60,7 +63,10 @@ class VsockListener:
             (from_client, (remote_cid, remote_port)) = self.sock.accept()
             # Read 1024 bytes at a time
             while True:
-                data = from_client.recv(1024).decode()
+                try:
+                    data = from_client.recv(1024).decode()
+                except socket.error:
+                    break
                 if not data:
                     break
                 print(data, end='', flush=True)


### PR DESCRIPTION
The python vsock-sample shows how to send and receive
data in a one-shot manner between the instance and the
enclave.

If the client loops instance-side opening and closing
sockets, the server can get a socket disconnected error
and it shall exit, causing the enclave to terminate.

To fix this, catch this exception and resume the server
loop for new connections. This way, the enclave remains
up as the server does not exit anymore.

Signed-off-by: Alexandru Ciobotaru <alcioa@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
