### PR TITLE
Improve vsock_sample for Rust

### DIFF
--- a/vsock_sample/rs/src/protocol_helpers.rs
+++ b/vsock_sample/rs/src/protocol_helpers.rs
@@ -29,7 +29,11 @@ pub fn send_loop(fd: RawFd, buf: &[u8], len: u64) -> Result<(), String> {
         let size = match send(fd, &buf[send_bytes..len], MsgFlags::empty()) {
             Ok(size) => size,
             Err(nix::Error::Sys(EINTR)) => 0,
-            Err(err) => return Err(format!("{:?}", err)),
+            Err(err) => {
+                return Err(format!(
+                    "{err:?}: sent {recv_bytes} bytes of expected {len}"
+                ))
+            }
         };
         send_bytes += size;
     }
@@ -46,7 +50,11 @@ pub fn recv_loop(fd: RawFd, buf: &mut [u8], len: u64) -> Result<(), String> {
         let size = match recv(fd, &mut buf[recv_bytes..len], MsgFlags::empty()) {
             Ok(size) => size,
             Err(nix::Error::Sys(EINTR)) => 0,
-            Err(err) => return Err(format!("{:?}", err)),
+            Err(err) => {
+                return Err(format!(
+                    "{err:?}: received {recv_bytes} bytes of expected {len}"
+                ))
+            }
         };
         recv_bytes += size;
     }


### PR DESCRIPTION
*Description of changes:*

As of dc4bba3d99bc4988a87ce7775cf1bc554537da16, in the case where parent instance is the server and the enclave is the client, the `protocol_helpers::recv_loop` function (running within server) errors with `ECONNRESET` before it can read the data sent by the client. The client has forcibly closed both send and receive on the connection.

This is because `VsockSocket::drop` called [shutdown](https://docs.rs/nix/0.29.0/nix/sys/socket/fn.shutdown.html) with [`Shutdown::Both`](https://docs.rs/nix/0.29.0/nix/sys/socket/enum.Shutdown.html#variant.Both) (and the `VsockSocket` struct was only used in the client code).

To fix this, the `VsockSocket` struct now carries the context of if it is the write (client) side or read (server) side of the connection, and `VsockSocket::drop` uses that mode when invoking shutdown. Now, the server as well as the client functions make use of `VsockSocket` to model the lifecycle of the connection.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.