### PR TITLE
Fix bug from PR #22

### DIFF
--- a/vsock_sample/rs/src/protocol_helpers.rs
+++ b/vsock_sample/rs/src/protocol_helpers.rs
@@ -31,7 +31,7 @@ pub fn send_loop(fd: RawFd, buf: &[u8], len: u64) -> Result<(), String> {
             Err(nix::Error::Sys(EINTR)) => 0,
             Err(err) => {
                 return Err(format!(
-                    "{err:?}: sent {recv_bytes} bytes of expected {len}"
+                    "{err:?}: sent {send_bytes} bytes of expected {len}"
                 ))
             }
         };


### PR DESCRIPTION
Copy-paste induced error in
- https://github.com/aws/aws-nitro-enclaves-samples/pull/22

```
error[E0425]: cannot find value `recv_bytes` in this scope
  --> src/protocol_helpers.rs:34:37
   |
34 |                     "{err:?}: sent {recv_bytes} bytes of expected {len}"
   |                                     ^^^^^^^^^^ help: a local variable with a similar name exists: `send_bytes`
```
