### PR TITLE
handle return value of 0 from recv in recv_loop

### DIFF
--- a/vsock_sample/rs/src/protocol_helpers.rs
+++ b/vsock_sample/rs/src/protocol_helpers.rs
@@ -48,6 +48,11 @@ pub fn recv_loop(fd: RawFd, buf: &mut [u8], len: u64) -> Result<(), String> {
 
     while recv_bytes < len {
         let size = match recv(fd, &mut buf[recv_bytes..len], MsgFlags::empty()) {
+            Ok(0) => {
+                return Err(format!(
+                    "Peer closed connection; received {recv_bytes} bytes of expected {len}"
+                ))
+            }
             Ok(size) => size,
             Err(nix::Error::Sys(EINTR)) => 0,
             Err(err) => {


### PR DESCRIPTION
Issue raised in
- https://github.com/aws/aws-nitro-enclaves-cli/pull/609

Replicating similar fix here.
Indicate count of bytes received and expected bytes in error string.

---

Documentation links:
- https://docs.rs/nix/latest/nix/sys/socket/fn.recv.html
- https://pubs.opengroup.org/onlinepubs/9699919799/functions/recv.html
- https://man7.org/linux/man-pages/man2/recv.2.html

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
